### PR TITLE
Fix "broadcast which requires authentication, but client was not authenticated"

### DIFF
--- a/Assets/Dissonance/Integrations/FishNet/DissonanceFishNetComms.cs
+++ b/Assets/Dissonance/Integrations/FishNet/DissonanceFishNetComms.cs
@@ -146,7 +146,7 @@ namespace Dissonance.Integrations.FishNet
                 LoggingHelper.RunningAs(_currentNetworkMode);
             }
             
-            // If client only & dirty, stop client
+            // If client only & dirty, start dissonance
             else if(NetworkManager.ClientManager.Started)
             {
                 if (_currentNetworkMode == NetworkMode.Client) return;


### PR DESCRIPTION
If `DissonanceFishNetComms` is present and the server uses an authenticator, the client may get kicked with the following errors:
```
ConnectionId 3 sent a broadcast which requires authentication, but client was not authenticated. Client has been disconnected.
ConnectionId 3 sent packetId 35684 without being authenticated. Connection will be kicked immediately.
```
This issue occurs because Dissonance starts and attempts to broadcast before the client is authenticated.

To fix this, modifications to `DissonanceFishNetComms.cs` are required to ensure that Dissonance starts only after the client has started and completed authentication.